### PR TITLE
[hotfix] CORS/cache headers

### DIFF
--- a/caddy/Caddyfile.local
+++ b/caddy/Caddyfile.local
@@ -17,6 +17,7 @@
 		Access-Control-Allow-Origin "http://localhost:5173" # allows the Vue app (running on localhost:5173) to make requests.
 		Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" # Specifies which methods are allowed.
 		Access-Control-Allow-Headers "X-API-Key, X-API-Username, X-API-Signature, Content-Type, User-Agent, If-None-Match" # allows the custom headers needed by the API.
+		Access-Control-Expose-Headers "ETag"
 	}
 
 	# This handles the browser's "preflight" OPTIONS request.

--- a/caddy/Caddyfile.prod
+++ b/caddy/Caddyfile.prod
@@ -35,6 +35,7 @@ oullin.io {
 			Access-Control-Allow-Origin "https://oullin.io"
 			Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
 			Access-Control-Allow-Headers "X-API-Key, X-API-Username, X-API-Signature, Content-Type, User-Agent, If-None-Match"
+			Access-Control-Expose-Headers "ETag"
 		}
 
 		@preflight {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded CORS support to allow the "If-None-Match" HTTP header in cross-origin requests and preflight checks for both local and production environments. This enables smoother integration with clients that use this header.
  * Added exposure of the "ETag" header in cross-origin responses to improve client-side caching and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->