### PR TITLE
Add public middleware with basic rate limiting and timestamp checks

### DIFF
--- a/pkg/middleware/public_middleware.go
+++ b/pkg/middleware/public_middleware.go
@@ -1,0 +1,97 @@
+package middleware
+
+import (
+	baseHttp "net/http"
+	"strings"
+	"time"
+
+	"github.com/oullin/pkg/cache"
+	"github.com/oullin/pkg/http"
+	"github.com/oullin/pkg/limiter"
+	"github.com/oullin/pkg/middleware/mwguards"
+	"github.com/oullin/pkg/portal"
+)
+
+// PublicMiddleware provides basic protections for public endpoints.
+// It enforces a timestamp check to prevent replay attacks and applies
+// a simple in-memory rate limiter keyed by client IP. Reuse of a
+// request ID within a TTL window is rejected via TTLCache.
+type PublicMiddleware struct {
+	clockSkew      time.Duration
+	disallowFuture bool
+	requestTTL     time.Duration
+	rateLimiter    *limiter.MemoryLimiter
+	requestCache   *cache.TTLCache
+	now            func() time.Time
+}
+
+// MakePublicMiddleware constructs a PublicMiddleware with sane defaults.
+func MakePublicMiddleware() PublicMiddleware {
+	return PublicMiddleware{
+		clockSkew:      5 * time.Minute,
+		disallowFuture: true,
+		requestTTL:     5 * time.Minute,
+		rateLimiter:    limiter.NewMemoryLimiter(1*time.Minute, 10),
+		requestCache:   cache.NewTTLCache(),
+		now:            time.Now,
+	}
+}
+
+func (p PublicMiddleware) Handle(next http.ApiHandler) http.ApiHandler {
+	return func(w baseHttp.ResponseWriter, r *baseHttp.Request) *http.ApiError {
+		if err := p.guardDependencies(); err != nil {
+			return err
+		}
+
+		reqID := strings.TrimSpace(r.Header.Get(portal.RequestIDHeader))
+		ts := strings.TrimSpace(r.Header.Get(portal.TimestampHeader))
+		if reqID == "" || ts == "" {
+			return mwguards.InvalidRequestError("Invalid authentication headers", "")
+		}
+
+		ip := portal.ParseClientIP(r)
+		if ip == "" {
+			return mwguards.InvalidRequestError("Invalid client IP", "")
+		}
+
+		limiterKey := ip
+		if p.rateLimiter.TooMany(limiterKey) {
+			return mwguards.RateLimitedError("Too many requests", "Too many requests for key: "+limiterKey)
+		}
+
+		vt := NewValidTimestamp(ts, p.now)
+		if err := vt.Validate(p.clockSkew, p.disallowFuture); err != nil {
+			return err
+		}
+
+		key := limiterKey + "|" + reqID
+		if p.requestCache.UseOnce(key, p.requestTTL) {
+			p.rateLimiter.Fail(limiterKey)
+			return mwguards.UnauthenticatedError(
+				"Invalid request id",
+				"duplicate request id: "+key,
+				map[string]any{"key": key, "limiter_key": limiterKey},
+			)
+		}
+
+		return next(w, r)
+	}
+}
+
+func (p PublicMiddleware) guardDependencies() *http.ApiError {
+	missing := []string{}
+	if p.requestCache == nil {
+		missing = append(missing, "requestCache")
+	}
+	if p.rateLimiter == nil {
+		missing = append(missing, "rateLimiter")
+	}
+	if len(missing) > 0 {
+		return mwguards.UnauthenticatedError(
+			"public middleware missing dependencies",
+			"public middleware missing dependencies: "+strings.Join(missing, ","),
+			map[string]any{"missing": missing},
+		)
+	}
+	return nil
+}

--- a/pkg/middleware/public_middleware_test.go
+++ b/pkg/middleware/public_middleware_test.go
@@ -1,0 +1,80 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	pkgHttp "github.com/oullin/pkg/http"
+	"github.com/oullin/pkg/limiter"
+)
+
+func TestPublicMiddleware_InvalidHeaders(t *testing.T) {
+	pm := MakePublicMiddleware()
+	handler := pm.Handle(func(w http.ResponseWriter, r *http.Request) *pkgHttp.ApiError { return nil })
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Request-ID", "req-1")
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	if err := handler(rec, req); err == nil || err.Status != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized for missing timestamp, got %#v", err)
+	}
+}
+
+func TestPublicMiddleware_TimestampExpired(t *testing.T) {
+	pm := MakePublicMiddleware()
+	base := time.Unix(1_700_000_000, 0)
+	pm.now = func() time.Time { return base }
+	handler := pm.Handle(func(w http.ResponseWriter, r *http.Request) *pkgHttp.ApiError { return nil })
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Request-ID", "req-1")
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	old := base.Add(-10 * time.Minute).Unix()
+	req.Header.Set("X-API-Timestamp", strconv.FormatInt(old, 10))
+	if err := handler(rec, req); err == nil || err.Status != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized for old timestamp, got %#v", err)
+	}
+}
+
+func TestPublicMiddleware_RateLimitAndReplay(t *testing.T) {
+	pm := MakePublicMiddleware()
+	pm.rateLimiter = limiter.NewMemoryLimiter(time.Minute, 1)
+	base := time.Unix(1_700_000_000, 0)
+	pm.now = func() time.Time { return base }
+	handler := pm.Handle(func(w http.ResponseWriter, r *http.Request) *pkgHttp.ApiError { return nil })
+
+	// First request succeeds
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest("GET", "/", nil)
+	req1.Header.Set("X-Request-ID", "abc")
+	req1.Header.Set("X-API-Timestamp", strconv.FormatInt(base.Unix(), 10))
+	req1.Header.Set("X-Forwarded-For", "1.2.3.4")
+	if err := handler(rec1, req1); err != nil {
+		t.Fatalf("first request failed: %#v", err)
+	}
+
+	// Replay with same request ID should be unauthorized
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.Header.Set("X-Request-ID", "abc")
+	req2.Header.Set("X-API-Timestamp", strconv.FormatInt(base.Unix(), 10))
+	req2.Header.Set("X-Forwarded-For", "1.2.3.4")
+	if err := handler(rec2, req2); err == nil || err.Status != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized for replay, got %#v", err)
+	}
+
+	// New request after replay should hit rate limit
+	rec3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest("GET", "/", nil)
+	req3.Header.Set("X-Request-ID", "def")
+	req3.Header.Set("X-API-Timestamp", strconv.FormatInt(base.Unix(), 10))
+	req3.Header.Set("X-Forwarded-For", "1.2.3.4")
+	if err := handler(rec3, req3); err == nil || err.Status != http.StatusTooManyRequests {
+		t.Fatalf("expected rate limit error, got %#v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- introduce PublicMiddleware for IP-based rate limiting and timestamp validation
- block replayed requests via TTLCache and provide tests

## Testing
- `go test ./pkg/middleware -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68be7b7819608333a4c727b82c5b3f1e