### PR TITLE
Improve token middleware time handling and signature body parsing

### DIFF
--- a/handler/signatures.go
+++ b/handler/signatures.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	baseHttp "net/http"
 	"time"
@@ -37,8 +36,10 @@ func (s *SignaturesHandler) Generate(w baseHttp.ResponseWriter, r *baseHttp.Requ
 		req payload.SignatureRequest
 	)
 
-	limited := io.LimitReader(r.Body, http.MaxRequestSize)
-	if err = json.NewDecoder(limited).Decode(&req); err != nil {
+	r.Body = baseHttp.MaxBytesReader(w, r.Body, http.MaxRequestSize)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err = dec.Decode(&req); err != nil {
 		return http.LogBadRequestError("could not parse the given data.", err)
 	}
 

--- a/handler/signatures_test.go
+++ b/handler/signatures_test.go
@@ -1,0 +1,19 @@
+package handler
+
+import (
+	nethttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/oullin/pkg/portal"
+)
+
+func TestSignaturesHandlerGenerate_ParseError(t *testing.T) {
+	h := SignaturesHandler{Validator: portal.GetDefaultValidator()}
+	req := httptest.NewRequest("POST", "/signatures", strings.NewReader("{"))
+	rec := httptest.NewRecorder()
+	if err := h.Generate(rec, req); err == nil || err.Status != nethttp.StatusBadRequest {
+		t.Fatalf("expected parse error, got %#v", err)
+	}
+}

--- a/handler/signatures_test.go
+++ b/handler/signatures_test.go
@@ -1,11 +1,14 @@
 package handler
 
 import (
+	"fmt"
 	nethttp "net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	apih "github.com/oullin/pkg/http"
 	"github.com/oullin/pkg/portal"
 )
 
@@ -15,5 +18,30 @@ func TestSignaturesHandlerGenerate_ParseError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	if err := h.Generate(rec, req); err == nil || err.Status != nethttp.StatusBadRequest {
 		t.Fatalf("expected parse error, got %#v", err)
+	}
+}
+
+func TestSignaturesHandlerGenerate_UnknownField(t *testing.T) {
+	h := SignaturesHandler{Validator: portal.GetDefaultValidator()}
+	body := fmt.Sprintf(`{"nonce":"%s","public_key":"%s","username":"%s","timestamp":%d,"extra":"nope"}`,
+		strings.Repeat("a", 32),
+		strings.Repeat("b", 64),
+		"validuser",
+		time.Now().Unix(),
+	)
+	req := httptest.NewRequest("POST", "/signatures", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	if err := h.Generate(rec, req); err == nil || err.Status != nethttp.StatusBadRequest {
+		t.Fatalf("expected unknown field error, got %#v", err)
+	}
+}
+
+func TestSignaturesHandlerGenerate_BodyTooLarge(t *testing.T) {
+	h := SignaturesHandler{Validator: portal.GetDefaultValidator()}
+	large := `{"nonce":"` + strings.Repeat("a", apih.MaxRequestSize+1) + `"}`
+	req := httptest.NewRequest("POST", "/signatures", strings.NewReader(large))
+	rec := httptest.NewRecorder()
+	if err := h.Generate(rec, req); err == nil || err.Status != nethttp.StatusBadRequest {
+		t.Fatalf("expected body too large error, got %#v", err)
 	}
 }

--- a/pkg/middleware/token_middleware.go
+++ b/pkg/middleware/token_middleware.go
@@ -215,7 +215,7 @@ func (t TokenCheckMiddleware) HasInvalidSignature(headers AuthTokenHeaders, apiK
 		Key:        apiKey,
 		Signature:  byteSignature,
 		Origin:     headers.IntendedOriginURL,
-		ServerTime: time.Now(),
+		ServerTime: t.now(),
 	}
 
 	signature := t.ApiKeys.FindSignatureFrom(entity)


### PR DESCRIPTION
## Summary
- Inject configurable time in token middleware signature lookup
- Stream and limit signature request body, surface encode errors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be7a61c75483338a42e70eee040684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Enforced a maximum request size for signature submissions to prevent oversized payloads.
  - Improved JSON parsing to reject unknown fields and return clearer 400 errors for invalid data.
  - Strengthened response encoding error handling to avoid silent failures.

- Chores
  - Token validation now uses an injectable time source for improved reliability and testability.
  - No changes to public APIs or user workflows.

- Tests
  - Added tests covering parse errors, unknown fields, oversized bodies, and custom clock behavior for token validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->