### PR TITLE
Add keep-alive monitoring endpoint

### DIFF
--- a/handler/keep_alive.go
+++ b/handler/keep_alive.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"github.com/oullin/handler/payload"
+	"github.com/oullin/pkg/http"
+	baseHttp "net/http"
+)
+
+type KeepAliveHandler struct{}
+
+func MakeKeepAliveHandler() KeepAliveHandler {
+	return KeepAliveHandler{}
+}
+
+func (h KeepAliveHandler) Handle(w baseHttp.ResponseWriter, r *baseHttp.Request) *http.ApiError {
+	resp := http.MakeResponseFrom("0.0.1", w, r)
+	data := payload.KeepAliveResponse{Message: "alive"}
+	if err := resp.RespondOk(data); err != nil {
+		return http.LogInternalError("could not encode keep alive response", err)
+	}
+	return nil
+}

--- a/handler/keep_alive_test.go
+++ b/handler/keep_alive_test.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/oullin/handler/payload"
+)
+
+func TestKeepAliveHandler(t *testing.T) {
+	h := MakeKeepAliveHandler()
+	req := httptest.NewRequest("GET", "/keep-alive", nil)
+	rec := httptest.NewRecorder()
+	if err := h.Handle(rec, req); err != nil {
+		t.Fatalf("handle err: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var resp payload.KeepAliveResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Message != "alive" {
+		t.Fatalf("unexpected message: %s", resp.Message)
+	}
+}

--- a/handler/payload/keep_alive.go
+++ b/handler/payload/keep_alive.go
@@ -1,0 +1,5 @@
+package payload
+
+type KeepAliveResponse struct {
+	Message string `json:"message"`
+}

--- a/metal/kernel/app.go
+++ b/metal/kernel/app.go
@@ -69,6 +69,7 @@ func (a *App) Boot() {
 
 	router := *a.router
 
+	router.KeepAlive()
 	router.Profile()
 	router.Experience()
 	router.Projects()

--- a/metal/kernel/router.go
+++ b/metal/kernel/router.go
@@ -80,6 +80,13 @@ func (r *Router) Signature() {
 	r.Mux.HandleFunc("POST /generate-signature", generate)
 }
 
+func (r *Router) KeepAlive() {
+	abstract := handler.MakeKeepAliveHandler()
+	handle := r.PublicPipelineFor(abstract.Handle)
+
+	r.Mux.HandleFunc("GET /keep-alive", handle)
+}
+
 func (r *Router) Profile() {
 	addStaticRoute(r, "/profile", "./storage/fixture/profile.json", handler.MakeProfileHandler)
 }

--- a/metal/kernel/router_keepalive_test.go
+++ b/metal/kernel/router_keepalive_test.go
@@ -1,0 +1,43 @@
+package kernel
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/oullin/pkg/middleware"
+	"github.com/oullin/pkg/portal"
+)
+
+func TestKeepAliveRoute_PublicMiddleware(t *testing.T) {
+	r := Router{
+		Mux: http.NewServeMux(),
+		Pipeline: middleware.Pipeline{
+			PublicMiddleware: middleware.MakePublicMiddleware("", false),
+		},
+	}
+	r.KeepAlive()
+
+	t.Run("request without public headers is unauthorized", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/keep-alive", nil)
+		rec := httptest.NewRecorder()
+		r.Mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+		}
+	})
+
+	t.Run("request with public headers succeeds", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/keep-alive", nil)
+		req.Header.Set(portal.RequestIDHeader, "req-1")
+		req.Header.Set(portal.TimestampHeader, fmt.Sprintf("%d", time.Now().Unix()))
+		req.Header.Set("X-Forwarded-For", "1.2.3.4")
+		rec := httptest.NewRecorder()
+		r.Mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add keep-alive handler and payload
- expose GET `/keep-alive` through public middleware
- test keep-alive handler and route protections

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bfc94809b48333bdd54d4fa40a135d