### PR TITLE
Align ping handler tests with new auth requirements

### DIFF
--- a/handler/ping_test.go
+++ b/handler/ping_test.go
@@ -8,12 +8,13 @@ import (
 	"time"
 
 	"github.com/oullin/handler/payload"
+	"github.com/oullin/metal/env"
+	"github.com/oullin/pkg/portal"
 )
 
 func TestPingHandler(t *testing.T) {
-	t.Setenv("PING_USERNAME", "user")
-	t.Setenv("PING_PASSWORD", "pass")
-	h := MakePingHandler()
+	e := env.Ping{Username: "user", Password: "pass"}
+	h := MakePingHandler(&e)
 
 	t.Run("valid credentials", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/ping", nil)
@@ -32,11 +33,8 @@ func TestPingHandler(t *testing.T) {
 		if resp.Message != "pong" {
 			t.Fatalf("unexpected message: %s", resp.Message)
 		}
-		if _, err := time.Parse("2006-01-02", resp.Date); err != nil {
-			t.Fatalf("invalid date: %v", err)
-		}
-		if _, err := time.Parse("15:04:05", resp.Time); err != nil {
-			t.Fatalf("invalid time: %v", err)
+		if _, err := time.Parse(portal.DatesLayout, resp.DateTime); err != nil {
+			t.Fatalf("invalid datetime: %v", err)
 		}
 	})
 

--- a/metal/kernel/kernel_test.go
+++ b/metal/kernel/kernel_test.go
@@ -34,6 +34,8 @@ func validEnvVars(t *testing.T) {
 	t.Setenv("ENV_SENTRY_DSN", "dsn")
 	t.Setenv("ENV_SENTRY_CSP", "csp")
 	t.Setenv("ENV_PUBLIC_ALLOWED_IP", "1.2.3.4")
+	t.Setenv("PING_USERNAME", "1234567890abcdef")
+	t.Setenv("PING_PASSWORD", "abcdef1234567890")
 }
 
 func TestMakeEnv(t *testing.T) {
@@ -81,7 +83,9 @@ func TestIgnite(t *testing.T) {
 		"ENV_HTTP_HOST=localhost\n" +
 		"ENV_HTTP_PORT=8080\n" +
 		"ENV_SENTRY_DSN=dsn\n" +
-		"ENV_SENTRY_CSP=csp\n"
+		"ENV_SENTRY_CSP=csp\n" +
+		"PING_USERNAME=1234567890abcdef\n" +
+		"PING_PASSWORD=abcdef1234567890\n"
 
 	f, err := os.CreateTemp("", "envfile")
 


### PR DESCRIPTION
## Summary
- adapt ping handler tests to new env-based basic auth and datetime response
- include ping credentials in environment configuration tests
- simplify router ping tests to reflect basic auth-only protection

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bff127274c8333bd9a8831bdd15f1c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ping endpoint now requires Basic Auth; credentials are configurable via environment variables.
  * Ping response consolidates date and time into a single DateTime field using a standardized format.
* **Tests**
  * Updated tests to use environment-based credentials and validate the new DateTime response format.
  * Simplified ping route tests to cover valid and invalid authentication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->