### PR TITLE
ci: run gofmt workflow only for style label

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -2,10 +2,7 @@ name: Go Fmt
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
-  push:
-    branches:
-      - main
+    types: [labeled]
 
 permissions:
     contents: write
@@ -13,7 +10,7 @@ permissions:
 
 jobs:
     gofmt:
-        if: github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'style')
+        if: github.event.label.name == 'style'
         strategy:
             matrix:
                 go-version: [1.25.1]
@@ -25,7 +22,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
               with:
-                  ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+                  ref: ${{ github.head_ref }}
                   fetch-depth: 0
 
             - name: Install Go
@@ -37,13 +34,11 @@ jobs:
               run: gofmt -w -s .
 
             - name: Check for formatting changes (dry run)
-              if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing') }}
               run: |
                 git diff --exit-code || echo "::warning::Formatting changes would be applied in normal mode"
               continue-on-error: true
 
             - name: Commit Changes to PR
-              if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing') }}
               uses: stefanzweifel/git-auto-commit-action@v6.0.1
               with:
                   commit_message: apply coding style fixes
@@ -54,44 +49,3 @@ jobs:
                   commit_user_email: ${{ secrets.GUS_GH_EMAIL }}
                   commit_author: gocanto <gocanto@users.noreply.github.com>
                   branch: ${{ github.head_ref }}
-
-            - name: Create branch for formatting changes
-              if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-              run: |
-                # Check if there are any changes after formatting
-                if ! git diff --quiet; then
-                  # Create a new branch with timestamp
-                  BRANCH_NAME="gofmt-fixes-$(date +%Y%m%d-%H%M%S)"
-                  git checkout -b $BRANCH_NAME
-
-                  # Configure git
-                  git config user.name "GitHub Actions"
-                  git config user.email "${{ secrets.GUS_GH_EMAIL }}"
-
-                  # Commit changes
-                  git add .
-                  git commit -m "Apply Go formatting fixes"
-
-                  # Push the branch
-                  git push origin $BRANCH_NAME
-
-                  # Set output for next step
-                  echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-                  echo "HAS_CHANGES=true" >> $GITHUB_ENV
-                else
-                  echo "No formatting changes needed"
-                  echo "HAS_CHANGES=false" >> $GITHUB_ENV
-                fi
-
-            - name: Create Pull Request
-              if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && env.HAS_CHANGES == 'true' }}
-              uses: peter-evans/create-pull-request@v6
-              with:
-                token: ${{ secrets.GITHUB_TOKEN }}
-                commit-message: Apply Go formatting fixes
-                title: "Auto: Apply Go formatting fixes"
-                body: |
-                  This PR was automatically created by the Go Fmt GitHub Action.
-                  It applies Go formatting standards to the codebase.
-                branch: ${{ env.BRANCH_NAME }}
-                base: main


### PR DESCRIPTION
## Summary
- run gofmt GitHub Action only when a PR is labeled `style`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c0d6749f0083339385c1c58ec89425