### PR TITLE
chore: Aligment + Cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,9 +28,7 @@ CADDY_LOGS_PATH="./storage/logs/caddy"
 ENV_DOCKER_USER="gocanto"
 ENV_DOCKER_USER_GROUP="ggroup"
 
-# --- Testing Token
-#     These variables are not intended to be used in production, but in the console interface (option: 3).
-#     This procedure facilitates the signatures creation for local testing/development.
-#     For more info, please see: cli/main.go
-ENV_LOCAL_TOKEN_ACCOUNT=
-ENV_LOCAL_TOKEN_SECRET=
+# --- Basic Http auth credentials.
+#     type: string, min: 16 characters.
+PING_USERNAME=
+PING_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -30,5 +30,5 @@ ENV_DOCKER_USER_GROUP="ggroup"
 
 # --- Basic Http auth credentials.
 #     type: string, min: 16 characters.
-PING_USERNAME=
-PING_PASSWORD=
+ENV_PING_USERNAME=
+ENV_PING_PASSWORD=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,8 @@ services:
           environment:
               ENV_DB_HOST: api-db
               ENV_DB_PORT: ${ENV_DB_PORT:-5432}
+              PING_USERNAME: ${PING_USERNAME}
+              PING_PASSWORD: ${PING_PASSWORD}
           networks:
             - oullin_net
           secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,8 +89,8 @@ services:
           environment:
               ENV_DB_HOST: api-db
               ENV_DB_PORT: ${ENV_DB_PORT:-5432}
-              PING_USERNAME: ${PING_USERNAME}
-              PING_PASSWORD: ${PING_PASSWORD}
+              ENV_PING_USERNAME: ${ENV_PING_USERNAME}
+              ENV_PING_PASSWORD: ${ENV_PING_PASSWORD}
           networks:
             - oullin_net
           secrets:

--- a/metal/kernel/factory.go
+++ b/metal/kernel/factory.go
@@ -96,8 +96,8 @@ func MakeEnv(validate *portal.Validator) *env.Environment {
 	}
 
 	pingEnvironment := env.Ping{
-		Username: env.GetEnvVar("PING_USERNAME"),
-		Password: env.GetEnvVar("PING_PASSWORD"),
+		Username: env.GetEnvVar("ENV_PING_USERNAME"),
+		Password: env.GetEnvVar("ENV_PING_PASSWORD"),
 	}
 
 	if _, err := validate.Rejects(app); err != nil {

--- a/metal/kernel/kernel_test.go
+++ b/metal/kernel/kernel_test.go
@@ -34,8 +34,8 @@ func validEnvVars(t *testing.T) {
 	t.Setenv("ENV_SENTRY_DSN", "dsn")
 	t.Setenv("ENV_SENTRY_CSP", "csp")
 	t.Setenv("ENV_PUBLIC_ALLOWED_IP", "1.2.3.4")
-	t.Setenv("PING_USERNAME", "1234567890abcdef")
-	t.Setenv("PING_PASSWORD", "abcdef1234567890")
+	t.Setenv("ENV_PING_USERNAME", "1234567890abcdef")
+	t.Setenv("ENV_PING_PASSWORD", "abcdef1234567890")
 }
 
 func TestMakeEnv(t *testing.T) {
@@ -84,8 +84,8 @@ func TestIgnite(t *testing.T) {
 		"ENV_HTTP_PORT=8080\n" +
 		"ENV_SENTRY_DSN=dsn\n" +
 		"ENV_SENTRY_CSP=csp\n" +
-		"PING_USERNAME=1234567890abcdef\n" +
-		"PING_PASSWORD=abcdef1234567890\n"
+		"ENV_PING_USERNAME=1234567890abcdef\n" +
+		"ENV_PING_PASSWORD=abcdef1234567890\n"
 
 	f, err := os.CreateTemp("", "envfile")
 

--- a/metal/makefile/db.mk
+++ b/metal/makefile/db.mk
@@ -16,8 +16,8 @@ DB_INFRA_SCRIPTS_PATH ?= $(DB_INFRA_ROOT_PATH)/scripts
 # --- Migrations
 DB_MIGRATE_DOCKER_ENV_FLAGS = -e ENV_DB_HOST=$(DB_DOCKER_SERVICE_NAME) \
                               -e ENV_DB_SSL_MODE=require \
-                              -e PING_USERNAME=0101010101010101 \
-                              -e PING_PASSWORD=0101010101010101
+                              -e ENV_PING_USERNAME=0101010101010101 \
+                              -e ENV_PING_PASSWORD=0101010101010101
 
 # --- SSL Certificate Files
 DB_INFRA_SERVER_CRT := $(DB_INFRA_SSL_PATH)/server.crt

--- a/metal/makefile/db.mk
+++ b/metal/makefile/db.mk
@@ -15,7 +15,9 @@ DB_INFRA_SCRIPTS_PATH ?= $(DB_INFRA_ROOT_PATH)/scripts
 
 # --- Migrations
 DB_MIGRATE_DOCKER_ENV_FLAGS = -e ENV_DB_HOST=$(DB_DOCKER_SERVICE_NAME) \
-                              -e ENV_DB_SSL_MODE=require
+                              -e ENV_DB_SSL_MODE=require \
+                              -e PING_USERNAME=0101010101010101 \
+                              -e PING_PASSWORD=0101010101010101
 
 # --- SSL Certificate Files
 DB_INFRA_SERVER_CRT := $(DB_INFRA_SSL_PATH)/server.crt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated example environment file to use HTTP Basic Auth credentials (ENV_PING_USERNAME, ENV_PING_PASSWORD) and removed legacy local token variables.
- Chores
  - Updated runtime, containers, and migration tooling to read the new credential variables for consistency across environments.
- Refactor
  - Standardized credential configuration by replacing token-based settings with basic auth variables, aligning naming with existing ENV_ conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->