### PR TITLE
Add local SEO image processing for posts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	go.opentelemetry.io/otel v1.37.0 // indirect
 	go.opentelemetry.io/otel/metric v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
+	golang.org/x/image v0.31.0 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.42.0 h1:chiH31gIWm57EkTXpwnqf8qeuMUi0yekh6mT2AvFlqI=
 golang.org/x/crypto v0.42.0/go.mod h1:4+rDnOTJhQCx2q7/j6rAN5XDw8kPjeaXEUR2eL94ix8=
+golang.org/x/image v0.31.0 h1:mLChjE2MV6g1S7oqbXC0/UcKijjm5fnJLUYKIYrLESA=
+golang.org/x/image v0.31.0/go.mod h1:R9ec5Lcp96v9FTF+ajwaH3uGxPH4fKfHHAVbUILxghA=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/metal/cli/seo/data.go
+++ b/metal/cli/seo/data.go
@@ -38,7 +38,7 @@ type TemplateData struct {
 }
 
 type TagOgData struct {
-	Type        string `validate:"required,oneof=website"`
+	Type        string `validate:"required,oneof=website article"`
 	Image       string `validate:"required,url"`
 	ImageAlt    string `validate:"required,min=10"`
 	ImageWidth  string `validate:"required"`

--- a/metal/cli/seo/defaults.go
+++ b/metal/cli/seo/defaults.go
@@ -18,6 +18,7 @@ const WebAboutUrl = "/about"
 
 const WebPostsName = "Posts"
 const WebPostsUrl = "/posts"
+const WebPostDetailUrl = "/post"
 
 const WebResumeName = "Resume"
 const WebResumeUrl = "/resume"

--- a/metal/cli/seo/images.go
+++ b/metal/cli/seo/images.go
@@ -1,0 +1,266 @@
+package seo
+
+import (
+	"errors"
+	"fmt"
+	"image"
+	_ "image/gif"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/oullin/handler/payload"
+	"github.com/oullin/pkg/portal"
+	"golang.org/x/image/draw"
+)
+
+type preparedImage struct {
+	URL  string
+	Mime string
+}
+
+const (
+	seoStorageDir       = "storage/seo"
+	postImagesDir       = "posts"
+	postImagesFolder    = "images"
+	seoImageWidth       = 1200
+	seoImageHeight      = 630
+	defaultImageQuality = 85
+)
+
+func (g *Generator) preparePostImage(post payload.PostResponse) (preparedImage, error) {
+	source := strings.TrimSpace(post.CoverImageURL)
+	if source == "" {
+		return preparedImage{}, errors.New("post has no cover image url")
+	}
+
+	img, format, err := fetchImage(source)
+	if err != nil {
+		return preparedImage{}, err
+	}
+
+	resized := resizeImage(img)
+
+	ext := determineExtension(source, format)
+	fileName := buildImageFileName(post.Slug, ext)
+
+	if err := os.MkdirAll(seoStorageDir, 0o755); err != nil {
+		return preparedImage{}, fmt.Errorf("create storage dir: %w", err)
+	}
+
+	tempPath := filepath.Join(seoStorageDir, fileName)
+	if err := saveImage(tempPath, resized, ext); err != nil {
+		return preparedImage{}, fmt.Errorf("write resized image: %w", err)
+	}
+
+	defer func() {
+		_ = os.Remove(tempPath)
+	}()
+
+	destDir := filepath.Join(g.Page.OutputDir, postImagesDir, postImagesFolder)
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return preparedImage{}, fmt.Errorf("create destination dir: %w", err)
+	}
+
+	destPath := filepath.Join(destDir, fileName)
+	if err := moveFile(tempPath, destPath); err != nil {
+		return preparedImage{}, fmt.Errorf("move resized image: %w", err)
+	}
+
+	relative := path.Join(postImagesDir, postImagesFolder, fileName)
+
+	return preparedImage{
+		URL:  g.siteURLFor(relative),
+		Mime: mimeFromExtension(ext),
+	}, nil
+}
+
+func fetchImage(source string) (image.Image, string, error) {
+	parsed, err := url.Parse(source)
+	if err != nil {
+		return nil, "", fmt.Errorf("parse url: %w", err)
+	}
+
+	reader, err := openImageSource(parsed)
+	if err != nil {
+		return nil, "", err
+	}
+	defer reader.Close()
+
+	img, format, err := image.Decode(reader)
+	if err != nil {
+		return nil, "", fmt.Errorf("decode image: %w", err)
+	}
+
+	return img, format, nil
+}
+
+func openImageSource(parsed *url.URL) (io.ReadCloser, error) {
+	switch parsed.Scheme {
+	case "http", "https":
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Get(parsed.String())
+		if err != nil {
+			return nil, fmt.Errorf("download image: %w", err)
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			defer resp.Body.Close()
+			return nil, fmt.Errorf("download image: unexpected status %s", resp.Status)
+		}
+
+		return resp.Body, nil
+	case "file":
+		return openLocalFile(parsed)
+	case "":
+		// Treat empty scheme as local file path
+		return os.Open(parsed.Path)
+	default:
+		return nil, fmt.Errorf("unsupported image scheme: %s", parsed.Scheme)
+	}
+}
+
+func openLocalFile(parsed *url.URL) (io.ReadCloser, error) {
+	pathValue := parsed.Path
+	if pathValue == "" {
+		pathValue = parsed.Opaque
+	}
+
+	if parsed.Host != "" {
+		pathValue = "//" + parsed.Host + pathValue
+	}
+
+	unescaped, err := url.PathUnescape(pathValue)
+	if err != nil {
+		return nil, fmt.Errorf("decode file path: %w", err)
+	}
+
+	return os.Open(unescaped)
+}
+
+func resizeImage(img image.Image) image.Image {
+	dst := image.NewRGBA(image.Rect(0, 0, seoImageWidth, seoImageHeight))
+	draw.CatmullRom.Scale(dst, dst.Bounds(), img, img.Bounds(), draw.Over, nil)
+
+	return dst
+}
+
+func determineExtension(source, format string) string {
+	ext := strings.ToLower(filepath.Ext(source))
+	if ext == "" {
+		ext = "." + strings.ToLower(format)
+	}
+
+	switch ext {
+	case ".jpeg":
+		return ".jpg"
+	case ".jpg", ".png":
+		return ext
+	default:
+		if format == "png" {
+			return ".png"
+		}
+
+		return ".jpg"
+	}
+}
+
+func buildImageFileName(slug, ext string) string {
+	trimmed := strings.TrimSpace(slug)
+	cleaned := strings.Trim(trimmed, "/")
+	if cleaned == "" {
+		cleaned = "post-image"
+	}
+
+	cleaned = strings.ReplaceAll(cleaned, " ", "-")
+
+	return cleaned + ext
+}
+
+func saveImage(path string, img image.Image, ext string) error {
+	fh, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	switch ext {
+	case ".png":
+		return pngEncode(fh, img)
+	default:
+		return jpegEncode(fh, img)
+	}
+}
+
+func pngEncode(w io.Writer, img image.Image) error {
+	encoder := &png.Encoder{CompressionLevel: png.DefaultCompression}
+	return encoder.Encode(w, img)
+}
+
+func jpegEncode(w io.Writer, img image.Image) error {
+	options := &jpeg.Options{Quality: defaultImageQuality}
+	return jpeg.Encode(w, img, options)
+}
+
+func moveFile(src, dst string) error {
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
+
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = out.Close()
+	}()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+
+	if err := out.Sync(); err != nil {
+		return err
+	}
+
+	return os.Remove(src)
+}
+
+func (g *Generator) siteURLFor(rel string) string {
+	base := strings.TrimSuffix(g.Page.SiteURL, "/")
+	rel = strings.TrimPrefix(rel, "/")
+
+	if base == "" {
+		return rel
+	}
+
+	return portal.SanitiseURL(base + "/" + rel)
+}
+
+func mimeFromExtension(ext string) string {
+	switch strings.ToLower(ext) {
+	case ".png":
+		return "image/png"
+	case ".jpg":
+		return "image/jpeg"
+	default:
+		return "image/png"
+	}
+}


### PR DESCRIPTION
## Summary
- download and resize post cover images into the SEO storage cache before moving them under the SPA output directory
- adjust post SEO metadata to use /post/{slug} canonicals and mark the OG type as article
- cover the new image workflow with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dcf39637048333a01a945b27a0cc21