### PR TITLE
Relocate SQL import tooling into importer package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ help:
 	@printf "  $(BOLD)$(GREEN)db:secure:show$(NC)   : Display database security configurations.\n"
 	@printf "  $(BOLD)$(GREEN)db:chmod$(NC)         : Adjust database file or directory permissions.\n"
 	@printf "  $(BOLD)$(GREEN)db:seed$(NC)          : Run database seeders to populate data.\n"
+	@printf "  $(BOLD)$(GREEN)db:import$(NC)        : Execute SQL statements from a file.\n"
 	@printf "  $(BOLD)$(GREEN)db:migrate$(NC)       : Run database migrations.\n"
 	@printf "  $(BOLD)$(GREEN)db:rollback$(NC)      : Rollback database migrations (usually the last batch).\n"
 	@printf "  $(BOLD)$(GREEN)db:migrate:create$(NC): Create a new database migration file.\n"

--- a/database/seeder/importer/cmd/importer/main.go
+++ b/database/seeder/importer/cmd/importer/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/oullin/database/seeder/importer"
+	"github.com/oullin/metal/env"
+	"github.com/oullin/metal/kernel"
+	"github.com/oullin/pkg/cli"
+	"github.com/oullin/pkg/portal"
+)
+
+var (
+	environment *env.Environment
+	sentryHub   *portal.Sentry
+)
+
+func init() {
+	secrets := kernel.Ignite("./.env", portal.GetDefaultValidator())
+
+	environment = secrets
+	sentryHub = kernel.MakeSentry(environment)
+}
+
+func main() {
+	var filePath string
+	flag.StringVar(&filePath, "file", "", "name or path to the SQL file located in ./storage/sql to execute")
+	flag.Parse()
+
+	if err := run(filePath); err != nil {
+		cli.Errorln(err.Error())
+		os.Exit(1)
+	}
+}
+
+func run(filePath string) error {
+	if filePath == "" {
+		return errors.New("missing required --file flag pointing to a SQL file")
+	}
+
+	if !environment.App.IsLocal() {
+		return fmt.Errorf("sql imports can only run in the local environment (current: %s)", environment.App.Type)
+	}
+
+	cli.ClearScreen()
+
+	dbConnection := kernel.MakeDbConnection(environment)
+	logs := kernel.MakeLogs(environment)
+
+	defer sentry.Flush(2 * time.Second)
+	defer logs.Close()
+	defer dbConnection.Close()
+	defer kernel.RecoverWithSentry(sentryHub)
+
+	if err := importer.SeedFromFile(dbConnection, environment, filePath); err != nil {
+		return err
+	}
+
+	cli.Successln("db seeded successfully from SQL file ...")
+	return nil
+}

--- a/database/seeder/importer/runner.go
+++ b/database/seeder/importer/runner.go
@@ -1,0 +1,932 @@
+package importer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/oullin/database"
+	"github.com/oullin/metal/env"
+)
+
+func SeedFromFile(conn *database.Connection, environment *env.Environment, filePath string) error {
+	cleanedPath, err := validateFilePath(filePath)
+	if err != nil {
+		return err
+	}
+
+	fileContents, err := readSQLFile(cleanedPath)
+	if err != nil {
+		return err
+	}
+
+	if conn == nil {
+		return errors.New("importer: database connection is required")
+	}
+
+	if environment == nil {
+		return errors.New("importer: environment is required")
+	}
+
+	statements, err := parseStatements(fileContents)
+	if err != nil {
+		return err
+	}
+
+	if len(statements) == 0 {
+		return errors.New("importer: SQL file did not contain any executable statements")
+	}
+
+	ctx := context.Background()
+
+	if err := prepareDatabase(ctx, conn, environment); err != nil {
+		return err
+	}
+
+	return executeStatements(ctx, conn, statements, executeOptions{
+		disableConstraints: true,
+		skipTables:         excludedSeedTables,
+	})
+}
+
+const storageSQLDir = "storage/sql"
+const migrationsRelativeDir = "database/infra/migrations"
+
+var excludedSeedTables = map[string]struct{}{
+	"api_keys":           {},
+	"api_key_signatures": {},
+}
+
+func prepareDatabase(ctx context.Context, conn *database.Connection, environment *env.Environment) error {
+	truncate := database.MakeTruncate(conn, environment)
+
+	if err := truncate.Execute(); err != nil {
+		return fmt.Errorf("importer: truncate database: %w", err)
+	}
+
+	if err := runMigrations(ctx, conn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func runMigrations(ctx context.Context, conn *database.Connection) error {
+	dir, err := locateMigrationsDir()
+	if err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("importer: read migrations directory: %w", err)
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(strings.ToLower(name), ".up.sql") {
+			files = append(files, filepath.Join(dir, name))
+		}
+	}
+
+	sort.Strings(files)
+
+	for _, path := range files {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("importer: read migration %s: %w", filepath.Base(path), err)
+		}
+
+		statements, err := parseStatements(contents)
+		if err != nil {
+			return fmt.Errorf("importer: parse migration %s: %w", filepath.Base(path), err)
+		}
+
+		if len(statements) == 0 {
+			continue
+		}
+
+		if err := executeStatements(ctx, conn, statements, executeOptions{}); err != nil {
+			return fmt.Errorf("importer: execute migration %s: %w", filepath.Base(path), err)
+		}
+	}
+
+	return nil
+}
+
+func locateMigrationsDir() (string, error) {
+	cleaned := filepath.Clean(migrationsRelativeDir)
+
+	if info, err := os.Stat(cleaned); err == nil && info.IsDir() {
+		return cleaned, nil
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("importer: determine working directory: %w", err)
+	}
+
+	dir := wd
+	for {
+		candidate := filepath.Join(dir, cleaned)
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return "", fmt.Errorf("importer: migrations directory %s not found", cleaned)
+}
+
+func validateFilePath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("importer: file path is required")
+	}
+
+	if filepath.IsAbs(path) {
+		return "", errors.New("importer: absolute file paths are not supported")
+	}
+
+	cleanedInput := filepath.Clean(path)
+	if ext := strings.ToLower(filepath.Ext(cleanedInput)); ext != ".sql" {
+		return "", fmt.Errorf("importer: unsupported file extension %q", filepath.Ext(cleanedInput))
+	}
+
+	base := filepath.Clean(storageSQLDir)
+	baseWithSep := base + string(os.PathSeparator)
+
+	var resolved string
+	if strings.HasPrefix(cleanedInput, baseWithSep) {
+		resolved = cleanedInput
+	} else {
+		resolved = filepath.Join(base, cleanedInput)
+	}
+
+	resolved = filepath.Clean(resolved)
+	if !strings.HasPrefix(resolved, baseWithSep) {
+		return "", fmt.Errorf("importer: file path must be within %s", base)
+	}
+
+	return resolved, nil
+}
+
+func readSQLFile(path string) ([]byte, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("importer: read file: %w", err)
+	}
+
+	if !utf8.Valid(contents) {
+		return nil, fmt.Errorf("importer: file %s contains non-UTF-8 data; ensure dumps are exported as plain text", path)
+	}
+
+	if len(bytes.TrimSpace(contents)) == 0 {
+		return nil, fmt.Errorf("importer: file %s is empty", path)
+	}
+
+	return contents, nil
+}
+
+type statement struct {
+	sql      string
+	copyData []byte
+	isCopy   bool
+}
+
+type executeOptions struct {
+	disableConstraints bool
+	skipTables         map[string]struct{}
+}
+
+func parseStatements(contents []byte) ([]statement, error) {
+	var stmts []statement
+
+	data := bytes.TrimSpace(contents)
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	leadingWhitespace := len(contents) - len(bytes.TrimLeftFunc(contents, func(r rune) bool {
+		return unicode.IsSpace(r)
+	}))
+
+	var (
+		idx            int
+		start          int
+		inSingleQuote  bool
+		inDoubleQuote  bool
+		inLineComment  bool
+		inBlockComment bool
+		dollarTag      string
+	)
+
+	start = skipIgnorableSections(data, start)
+	idx = start
+
+	for idx < len(data) {
+		b := data[idx]
+
+		switch {
+		case inLineComment:
+			if b == '\n' {
+				inLineComment = false
+			}
+			idx++
+			continue
+		case inBlockComment:
+			if b == '*' && idx+1 < len(data) && data[idx+1] == '/' {
+				inBlockComment = false
+				idx += 2
+				continue
+			}
+			idx++
+			continue
+		case dollarTag != "":
+			if b == '$' && hasDollarTag(data[idx:], dollarTag) {
+				idx += len(dollarTag) + 2
+				dollarTag = ""
+				continue
+			}
+			idx++
+			continue
+		case inSingleQuote:
+			if b == '\\' && idx+1 < len(data) {
+				idx += 2
+				continue
+			}
+			if b == '\'' {
+				inSingleQuote = false
+			}
+			idx++
+			continue
+		case inDoubleQuote:
+			if b == '"' {
+				inDoubleQuote = false
+			}
+			idx++
+			continue
+		}
+
+		if b == '-' && idx+1 < len(data) && data[idx+1] == '-' {
+			inLineComment = true
+			idx += 2
+			continue
+		}
+
+		if b == '/' && idx+1 < len(data) && data[idx+1] == '*' {
+			inBlockComment = true
+			idx += 2
+			continue
+		}
+
+		if b == '$' {
+			tag, ok := readDollarTag(data[idx:])
+			if ok {
+				dollarTag = tag
+				idx += len(tag) + 2
+				continue
+			}
+		}
+
+		if b == '\'' {
+			inSingleQuote = true
+			idx++
+			continue
+		}
+
+		if b == '"' {
+			inDoubleQuote = true
+			idx++
+			continue
+		}
+
+		if b != ';' {
+			idx++
+			continue
+		}
+
+		rawStmt := bytes.TrimSpace(data[start : idx+1])
+		idx++
+		if len(rawStmt) == 0 {
+			start = skipIgnorableSections(data, idx)
+			idx = start
+			continue
+		}
+
+		trimmed := strings.TrimSpace(string(rawStmt))
+		if isCopyFromStdin(trimmed) {
+			copyStart := skipIgnorableSections(data, idx)
+			copyLen, advance, err := extractCopyData(data[copyStart:])
+			if err != nil {
+				return nil, err
+			}
+
+			stmt := statement{
+				sql:      strings.TrimSpace(strings.TrimSuffix(trimmed, ";")),
+				copyData: append([]byte(nil), data[copyStart:copyStart+copyLen]...),
+				isCopy:   true,
+			}
+			stmts = append(stmts, stmt)
+
+			idx = copyStart + advance
+			start = skipIgnorableSections(data, idx)
+			idx = start
+			continue
+		}
+
+		stmt := statement{sql: strings.TrimSpace(strings.TrimSuffix(trimmed, ";"))}
+		stmts = append(stmts, stmt)
+
+		start = skipIgnorableSections(data, idx)
+		idx = start
+	}
+
+	start = skipIgnorableSections(data, start)
+	if start < len(data) {
+		if len(bytes.TrimSpace(data[start:])) != 0 {
+			originalIdx := start + leadingWhitespace
+			line, column := lineAndColumn(contents, originalIdx)
+			preview := formatSnippet(data[start:])
+			return nil, fmt.Errorf("importer: SQL file ended with an unterminated statement at line %d, column %d near %q", line, column, preview)
+		}
+	}
+
+	return stmts, nil
+}
+
+func skipIgnorableSections(data []byte, idx int) int {
+	for idx < len(data) {
+		r, size := utf8DecodeRune(data[idx:])
+		if size == 0 {
+			return idx
+		}
+		switch r {
+		case ' ', '\n', '\r', '\t':
+			idx += size
+			continue
+		}
+
+		if data[idx] == '-' && idx+1 < len(data) && data[idx+1] == '-' {
+			idx += 2
+			for idx < len(data) {
+				if data[idx] == '\n' || data[idx] == '\r' {
+					idx++
+					break
+				}
+				idx++
+			}
+			continue
+		}
+
+		if data[idx] == '/' && idx+1 < len(data) && data[idx+1] == '*' {
+			idx += 2
+			for idx < len(data) {
+				if data[idx] == '*' && idx+1 < len(data) && data[idx+1] == '/' {
+					idx += 2
+					break
+				}
+				idx++
+			}
+			continue
+		}
+
+		if data[idx] == '\\' {
+			idx++
+			for idx < len(data) && data[idx] != '\n' && data[idx] != '\r' {
+				idx++
+			}
+
+			if idx < len(data) {
+				if data[idx] == '\r' {
+					idx++
+					if idx < len(data) && data[idx] == '\n' {
+						idx++
+					}
+				} else if data[idx] == '\n' {
+					idx++
+				}
+			}
+
+			continue
+		}
+
+		return idx
+	}
+
+	return idx
+}
+
+func utf8DecodeRune(data []byte) (rune, int) {
+	if len(data) == 0 {
+		return 0, 0
+	}
+	r, size := utf8.DecodeRune(data)
+	if r == utf8.RuneError && size == 1 {
+		return rune(data[0]), 1
+	}
+	return r, size
+}
+
+func readDollarTag(data []byte) (string, bool) {
+	if len(data) < 2 || data[0] != '$' {
+		return "", false
+	}
+
+	end := 1
+	for end < len(data) {
+		c := data[end]
+		if c == '$' {
+			return string(data[1:end]), true
+		}
+		if !isDollarTagChar(c) {
+			return "", false
+		}
+		end++
+	}
+
+	return "", false
+}
+
+func isDollarTagChar(b byte) bool {
+	return b == '_' || b == '$' || unicode.IsLetter(rune(b)) || unicode.IsDigit(rune(b))
+}
+
+func hasDollarTag(data []byte, tag string) bool {
+	marker := "$" + tag + "$"
+	return len(data) >= len(marker) && string(data[:len(marker)]) == marker
+}
+
+func isCopyFromStdin(stmt string) bool {
+	upper := strings.ToUpper(stmt)
+	return strings.HasPrefix(upper, "COPY ") && strings.Contains(upper, "FROM STDIN")
+}
+
+func extractCopyData(data []byte) (int, int, error) {
+	patterns := []struct {
+		marker  []byte
+		include int
+	}{
+		{[]byte("\r\n\\.\r\n"), 2},
+		{[]byte("\n\\.\n"), 1},
+		{[]byte("\n\\.\r\n"), 1},
+		{[]byte("\r\n\\.\n"), 2},
+		{[]byte("\\.\r\n"), 0},
+		{[]byte("\\.\n"), 0},
+		{[]byte("\\."), 0},
+	}
+
+	for _, pattern := range patterns {
+		if idx := bytes.Index(data, pattern.marker); idx != -1 {
+			copyEnd := idx + pattern.include
+			advance := idx + len(pattern.marker)
+			return copyEnd, advance, nil
+		}
+	}
+
+	return 0, 0, errors.New("importer: COPY statement missing terminator")
+}
+
+func executeStatements(ctx context.Context, conn *database.Connection, statements []statement, opts executeOptions) error {
+	sqlDB, err := conn.Sql().DB()
+	if err != nil {
+		return fmt.Errorf("importer: retrieve sql db: %w", err)
+	}
+
+	sqlConn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("importer: acquire connection: %w", err)
+	}
+	defer sqlConn.Close()
+
+	var execErr error
+	err = sqlConn.Raw(func(driverConn interface{}) error {
+		stdlibConn, ok := driverConn.(*stdlib.Conn)
+		if !ok {
+			return errors.New("importer: unexpected driver connection type")
+		}
+
+		pgxConn := stdlibConn.Conn()
+		tx, err := pgxConn.BeginTx(ctx, pgx.TxOptions{})
+		if err != nil {
+			return fmt.Errorf("importer: begin transaction: %w", err)
+		}
+
+		committed := false
+		defer func() {
+			if committed {
+				return
+			}
+			if rbErr := tx.Rollback(ctx); rbErr != nil && !errors.Is(rbErr, pgx.ErrTxClosed) {
+				execErr = errors.Join(execErr, fmt.Errorf("importer: rollback failed: %w", rbErr))
+			}
+		}()
+
+		if opts.disableConstraints {
+			if _, err := tx.Exec(ctx, "SET LOCAL session_replication_role = 'replica'"); err != nil {
+				execErr = fmt.Errorf("importer: disable constraints failed: %w", err)
+				return execErr
+			}
+		}
+
+		for idx, stmt := range statements {
+			statementNumber := idx + 1
+			preview := formatSnippet([]byte(stmt.sql))
+
+			if skip, reason := shouldSkipStatement(stmt, opts.skipTables); skip {
+				fmt.Fprintf(os.Stderr, "importer: skipped statement %d near %q: %s\n", statementNumber, preview, reason)
+				continue
+			}
+			if stmt.isCopy {
+				if err := executeCopy(ctx, tx.Conn().PgConn(), stmt); err != nil {
+					execErr = fmt.Errorf("importer: executing COPY statement %d near %q failed: %w", statementNumber, preview, err)
+					return execErr
+				}
+				continue
+			}
+
+			nestedTx, err := tx.Begin(ctx)
+			if err != nil {
+				execErr = fmt.Errorf("importer: begin savepoint for statement %d near %q: %w", statementNumber, preview, err)
+				return execErr
+			}
+
+			if _, err := nestedTx.Exec(ctx, stmt.sql); err != nil {
+				if skip, reason := shouldSkipExecError(stmt, err); skip {
+					if rbErr := nestedTx.Rollback(ctx); rbErr != nil && !errors.Is(rbErr, pgx.ErrTxClosed) {
+						execErr = fmt.Errorf("importer: rollback savepoint for skipped statement %d near %q failed: %w", statementNumber, preview, rbErr)
+						return execErr
+					}
+					fmt.Fprintf(os.Stderr, "importer: skipped statement %d near %q: %s\n", statementNumber, preview, reason)
+					continue
+				}
+
+				if rbErr := nestedTx.Rollback(ctx); rbErr != nil && !errors.Is(rbErr, pgx.ErrTxClosed) {
+					execErr = errors.Join(fmt.Errorf("importer: executing SQL statement %d near %q failed: %w", statementNumber, preview, err), fmt.Errorf("importer: rollback savepoint failed: %w", rbErr))
+					return execErr
+				}
+
+				execErr = fmt.Errorf("importer: executing SQL statement %d near %q failed: %w", statementNumber, preview, err)
+				return execErr
+			}
+
+			if err := nestedTx.Commit(ctx); err != nil {
+				execErr = fmt.Errorf("importer: release savepoint for statement %d near %q failed: %w", statementNumber, preview, err)
+				return execErr
+			}
+		}
+
+		if err := tx.Commit(ctx); err != nil {
+			execErr = fmt.Errorf("importer: commit failed: %w", err)
+			return execErr
+		}
+
+		committed = true
+		return nil
+	})
+	if err != nil {
+		if execErr != nil {
+			return execErr
+		}
+		return err
+	}
+
+	if execErr != nil {
+		return execErr
+	}
+
+	return nil
+}
+
+func executeCopy(ctx context.Context, pgConn *pgconn.PgConn, stmt statement) error {
+	reader := bytes.NewReader(stmt.copyData)
+	sql := strings.TrimSpace(stmt.sql)
+	sql = strings.TrimSuffix(sql, ";")
+	if _, err := pgConn.CopyFrom(ctx, reader, sql); err != nil {
+		return fmt.Errorf("importer: executing COPY failed: %w", err)
+	}
+	return nil
+}
+
+func shouldSkipExecError(stmt statement, err error) (bool, string) {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false, ""
+	}
+
+	upper := strings.ToUpper(strings.TrimSpace(stmt.sql))
+
+	switch pgErr.Code {
+	case "42P07", "42P06", "42710":
+		if strings.HasPrefix(upper, "CREATE ") {
+			return true, fmt.Sprintf("object already exists (%s)", pgErr.Message)
+		}
+	case "42704":
+		if strings.Contains(upper, " OWNER TO ") {
+			return true, fmt.Sprintf("owner skipped (%s)", pgErr.Message)
+		}
+	case "42P01":
+		if strings.HasPrefix(upper, "ALTER TABLE") || strings.HasPrefix(upper, "DROP ") {
+			return true, fmt.Sprintf("relation skipped (%s)", pgErr.Message)
+		}
+	}
+
+	return false, ""
+}
+
+func shouldSkipStatement(stmt statement, skipTables map[string]struct{}) (bool, string) {
+	if len(skipTables) == 0 {
+		return false, ""
+	}
+
+	target, operation := statementTarget(stmt.sql)
+	if target == "" {
+		return false, ""
+	}
+
+	if !shouldExcludeIdentifier(target, skipTables) {
+		return false, ""
+	}
+
+	normalized := normalizeQualifiedIdentifier(target)
+	if normalized == "" {
+		normalized = target
+	}
+
+	if operation == "" {
+		operation = "statement"
+	}
+
+	return true, fmt.Sprintf("%s targets excluded identifier %s", operation, normalized)
+}
+
+func statementTarget(sql string) (string, string) {
+	trimmed := strings.TrimSpace(sql)
+	if trimmed == "" {
+		return "", ""
+	}
+
+	upper := strings.ToUpper(trimmed)
+
+	switch {
+	case strings.HasPrefix(upper, "COPY "):
+		rest := trimmed[5:]
+		token := firstIdentifier(rest, true)
+		return token, "COPY"
+	case strings.HasPrefix(upper, "INSERT INTO "):
+		rest := trimmed[len("INSERT INTO "):]
+		token := firstIdentifier(rest, true)
+		return token, "INSERT"
+	case strings.HasPrefix(upper, "UPDATE "):
+		rest := trimmed[len("UPDATE "):]
+		token := firstIdentifier(rest, false)
+		return token, "UPDATE"
+	case strings.HasPrefix(upper, "DELETE FROM "):
+		rest := trimmed[len("DELETE FROM "):]
+		token := firstIdentifier(rest, true)
+		return token, "DELETE"
+	case strings.HasPrefix(upper, "ALTER TABLE "):
+		rest := trimmed[len("ALTER TABLE "):]
+		token := firstIdentifier(rest, true)
+		return token, "ALTER TABLE"
+	case strings.HasPrefix(upper, "ALTER INDEX "):
+		rest := trimmed[len("ALTER INDEX "):]
+		token := firstIdentifier(rest, false)
+		return token, "ALTER INDEX"
+	case strings.HasPrefix(upper, "DROP TABLE "):
+		rest := trimmed[len("DROP TABLE "):]
+		token := firstIdentifier(rest, true)
+		return token, "DROP TABLE"
+	case strings.HasPrefix(upper, "DROP INDEX "):
+		rest := trimmed[len("DROP INDEX "):]
+		token := firstIdentifier(rest, false)
+		return token, "DROP INDEX"
+	case strings.HasPrefix(upper, "DROP SEQUENCE "):
+		rest := trimmed[len("DROP SEQUENCE "):]
+		token := firstIdentifier(rest, false)
+		return token, "DROP SEQUENCE"
+	case strings.HasPrefix(upper, "CREATE TABLE "):
+		rest := trimmed[len("CREATE TABLE "):]
+		token := firstIdentifier(rest, true)
+		return token, "CREATE TABLE"
+	case strings.HasPrefix(upper, "CREATE UNIQUE INDEX "):
+		onIdx := strings.Index(upper, " ON ")
+		if onIdx == -1 {
+			return "", ""
+		}
+		rest := trimmed[onIdx+4:]
+		token := firstIdentifier(rest, true)
+		return token, "CREATE INDEX"
+	case strings.HasPrefix(upper, "CREATE INDEX "):
+		onIdx := strings.Index(upper, " ON ")
+		if onIdx == -1 {
+			return "", ""
+		}
+		rest := trimmed[onIdx+4:]
+		token := firstIdentifier(rest, true)
+		return token, "CREATE INDEX"
+	case strings.HasPrefix(upper, "ALTER SEQUENCE "):
+		rest := trimmed[len("ALTER SEQUENCE "):]
+		token := firstIdentifier(rest, false)
+		return token, "ALTER SEQUENCE"
+	case strings.HasPrefix(upper, "SELECT ") && strings.Contains(upper, "SETVAL"):
+		name := extractSetvalIdentifier(trimmed)
+		if name != "" {
+			return name, "SELECT"
+		}
+	}
+
+	return "", ""
+}
+
+func firstIdentifier(input string, allowOnly bool) string {
+	s := strings.TrimLeftFunc(input, unicode.IsSpace)
+	if allowOnly {
+		if next, ok := trimLeadingKeyword(s, "ONLY"); ok {
+			s = next
+		}
+	}
+
+	prefixes := []string{"IF NOT EXISTS", "IF EXISTS"}
+	for _, prefix := range prefixes {
+		if next, ok := trimLeadingKeyword(s, prefix); ok {
+			s = next
+		}
+	}
+
+	s = strings.TrimLeftFunc(s, unicode.IsSpace)
+	if s == "" {
+		return ""
+	}
+
+	var end int
+	inQuotes := false
+	for end < len(s) {
+		c := s[end]
+		if c == '"' {
+			inQuotes = !inQuotes
+			end++
+			continue
+		}
+		if !inQuotes {
+			if unicode.IsSpace(rune(c)) || c == '(' || c == ';' {
+				break
+			}
+		}
+		end++
+	}
+
+	return strings.TrimSpace(s[:end])
+}
+
+func trimLeadingKeyword(s, keyword string) (string, bool) {
+	s = strings.TrimLeftFunc(s, unicode.IsSpace)
+	if len(s) < len(keyword) {
+		return s, false
+	}
+
+	candidate := s[:len(keyword)]
+	if strings.EqualFold(candidate, keyword) {
+		if len(s) == len(keyword) {
+			return "", true
+		}
+		remainder := s[len(keyword):]
+		if len(remainder) == 0 || unicode.IsSpace(rune(remainder[0])) {
+			return remainder, true
+		}
+	}
+
+	return s, false
+}
+
+func extractSetvalIdentifier(sql string) string {
+	start := strings.Index(sql, "'")
+	if start == -1 {
+		return ""
+	}
+	end := strings.Index(sql[start+1:], "'")
+	if end == -1 {
+		return ""
+	}
+	return sql[start+1 : start+1+end]
+}
+
+func shouldExcludeIdentifier(identifier string, skip map[string]struct{}) bool {
+	normalized := normalizeQualifiedIdentifier(identifier)
+	if normalized == "" {
+		return false
+	}
+
+	if _, ok := skip[normalized]; ok {
+		return true
+	}
+
+	parts := strings.Split(normalized, ".")
+	last := parts[len(parts)-1]
+
+	if _, ok := skip[last]; ok {
+		return true
+	}
+
+	if strings.HasSuffix(last, "_id_seq") {
+		base := strings.TrimSuffix(last, "_id_seq")
+		if _, ok := skip[base]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func normalizeQualifiedIdentifier(identifier string) string {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return ""
+	}
+
+	parts := strings.Split(identifier, ".")
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		part = strings.Trim(part, "\"")
+		parts[i] = strings.ToLower(part)
+	}
+
+	return strings.Join(parts, ".")
+}
+
+func formatSnippet(data []byte) string {
+	const maxRunes = 120
+
+	snippet := strings.TrimSpace(string(data))
+	if snippet == "" {
+		return "<empty>"
+	}
+
+	replacer := strings.NewReplacer("\r", " ", "\n", " ", "\t", " ")
+	snippet = replacer.Replace(snippet)
+	snippet = strings.Join(strings.Fields(snippet), " ")
+
+	runes := []rune(snippet)
+	if len(runes) > maxRunes {
+		snippet = string(runes[:maxRunes-1]) + "…"
+	}
+
+	return snippet
+}
+
+func lineAndColumn(src []byte, index int) (int, int) {
+	line := 1
+	column := 1
+
+	if index < 0 {
+		index = 0
+	}
+	if index > len(src) {
+		index = len(src)
+	}
+
+	i := 0
+	for i < index {
+		b := src[i]
+		if b == '\r' {
+			line++
+			column = 1
+			if i+1 < len(src) && src[i+1] == '\n' {
+				i += 2
+				continue
+			}
+			i++
+			continue
+		}
+		if b == '\n' {
+			line++
+			column = 1
+			i++
+			continue
+		}
+
+		column++
+		i++
+	}
+
+	return line, column
+}

--- a/database/seeder/importer/runner_test.go
+++ b/database/seeder/importer/runner_test.go
@@ -1,0 +1,637 @@
+package importer_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	"github.com/oullin/database"
+	"github.com/oullin/database/seeder/importer"
+	"github.com/oullin/metal/env"
+)
+
+func TestSeedFromFileExecutesStatements(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), "CREATE TABLE widgets (id SERIAL PRIMARY KEY, name TEXT NOT NULL);\nINSERT INTO widgets (name) VALUES ('alpha'), ('beta');")
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("seed from file: %v", err)
+	}
+
+	var count int64
+	if err := conn.Sql().Table("widgets").Count(&count).Error; err != nil {
+		t.Fatalf("count widgets: %v", err)
+	}
+
+	if count != 2 {
+		t.Fatalf("expected 2 widgets, got %d", count)
+	}
+}
+
+func TestSeedFromFileRejectsNonSQLFile(t *testing.T) {
+	fileName := writeStorageFile(t, withSuffix(t, ".txt"), "SELECT 1;")
+
+	err := importer.SeedFromFile(nil, nil, fileName)
+	if err == nil || !strings.Contains(err.Error(), "unsupported file extension") {
+		t.Fatalf("expected extension error, got %v", err)
+	}
+}
+
+func TestSeedFromFileRequiresEnvironment(t *testing.T) {
+	conn, _, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), "SELECT 1;")
+
+	err := importer.SeedFromFile(conn, nil, fileName)
+	if err == nil || !strings.Contains(err.Error(), "environment is required") {
+		t.Fatalf("expected environment error, got %v", err)
+	}
+}
+
+func TestSeedFromFileRejectsAbsolutePath(t *testing.T) {
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), "SELECT 1;")
+
+	absPath, err := filepath.Abs(filepath.Join("storage", "sql", fileName))
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+
+	err = importer.SeedFromFile(nil, nil, absPath)
+	if err == nil || !strings.Contains(err.Error(), "absolute file paths") {
+		t.Fatalf("expected absolute path error, got %v", err)
+	}
+}
+
+func TestSeedFromFileRejectsTraversal(t *testing.T) {
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), "SELECT 1;")
+
+	err := importer.SeedFromFile(nil, nil, filepath.Join("..", fileName))
+	if err == nil || !strings.Contains(err.Error(), "within") {
+		t.Fatalf("expected traversal error, got %v", err)
+	}
+}
+
+func TestSeedFromFileFailsWhenFileMissing(t *testing.T) {
+	fileName := withSuffix(t, "_missing.sql")
+
+	err := importer.SeedFromFile(nil, nil, fileName)
+	if err == nil || !strings.Contains(err.Error(), "read file") {
+		t.Fatalf("expected read error, got %v", err)
+	}
+}
+
+func TestSeedFromFileFailsWhenFileEmpty(t *testing.T) {
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), "   \n\t")
+
+	err := importer.SeedFromFile(nil, nil, fileName)
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("expected empty file error, got %v", err)
+	}
+}
+
+func TestSeedFromFileRejectsNonUTF8Contents(t *testing.T) {
+	fileName := writeStorageBytes(t, withSuffix(t, ".sql"), []byte{0xff, 0xfe, 0xfd})
+
+	err := importer.SeedFromFile(nil, nil, fileName)
+	if err == nil || !strings.Contains(err.Error(), "non-UTF-8") {
+		t.Fatalf("expected non-UTF-8 error, got %v", err)
+	}
+}
+
+func TestSeedFromFileRequiresConnection(t *testing.T) {
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), "SELECT 1;")
+
+	err := importer.SeedFromFile(nil, testEnvironment(), fileName)
+	if err == nil || !strings.Contains(err.Error(), "connection") {
+		t.Fatalf("expected connection error, got %v", err)
+	}
+}
+
+func TestSeedFromFileRollsBackOnFailure(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), "CREATE TABLE gadgets (id SERIAL PRIMARY KEY);\nINSERT INTO gadgets (name) VALUES ('alpha');")
+
+	// The INSERT statement above is invalid because the table does not have a name column.
+	err := importer.SeedFromFile(conn, environment, fileName)
+	if err == nil {
+		t.Fatalf("expected error when executing invalid sql")
+	}
+
+	if !strings.Contains(err.Error(), "statement 2") {
+		t.Fatalf("expected error to identify failing statement, got %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "INSERT INTO gadgets") {
+		t.Fatalf("expected error to include statement preview, got %v", err)
+	}
+
+	if conn.Sql().Migrator().HasTable("gadgets") {
+		t.Fatalf("expected transaction rollback to drop gadgets table")
+	}
+}
+
+func TestSeedFromFileSupportsCopyFromStdin(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	contents := strings.Join([]string{
+		"CREATE TABLE supplies (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
+		"COPY supplies (id, name) FROM stdin;",
+		"1\tbolts",
+		"2\twashers",
+		"\\.",
+		"",
+	}, "\n")
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), contents)
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("seed from file: %v", err)
+	}
+
+	type supply struct {
+		ID   int
+		Name string
+	}
+
+	var rows []supply
+	if err := conn.Sql().Table("supplies").Order("id").Find(&rows).Error; err != nil {
+		t.Fatalf("query supplies: %v", err)
+	}
+
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 supplies, got %d", len(rows))
+	}
+
+	if rows[0].ID != 1 || rows[0].Name != "bolts" {
+		t.Fatalf("unexpected first row: %+v", rows[0])
+	}
+
+	if rows[1].ID != 2 || rows[1].Name != "washers" {
+		t.Fatalf("unexpected second row: %+v", rows[1])
+	}
+}
+
+func TestSeedFromFileLoadsDataOutOfConstraintOrder(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	contents := strings.Join([]string{
+		"CREATE TABLE parents (id BIGINT PRIMARY KEY, name TEXT NOT NULL);",
+		"CREATE TABLE children (id BIGINT PRIMARY KEY, parent_id BIGINT NOT NULL REFERENCES parents(id), name TEXT NOT NULL);",
+		"INSERT INTO children (id, parent_id, name) VALUES (1, 42, 'child-before-parent');",
+		"INSERT INTO parents (id, name) VALUES (42, 'parent-later');",
+	}, "\n")
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), contents)
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("seed from file: %v", err)
+	}
+
+	type child struct {
+		ID       int64
+		ParentID int64
+		Name     string
+	}
+
+	var rows []child
+	if err := conn.Sql().Table("children").Find(&rows).Error; err != nil {
+		t.Fatalf("query children: %v", err)
+	}
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(rows))
+	}
+
+	if rows[0].ParentID != 42 {
+		t.Fatalf("expected parent id 42, got %d", rows[0].ParentID)
+	}
+
+	var parentCount int64
+	if err := conn.Sql().Table("parents").Where("id = ?", 42).Count(&parentCount).Error; err != nil {
+		t.Fatalf("count parents: %v", err)
+	}
+
+	if parentCount != 1 {
+		t.Fatalf("expected parent to exist, got %d", parentCount)
+	}
+}
+
+func TestSeedFromFileSkipsExcludedTables(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	copyRow := strings.Join([]string{
+		"1",
+		"00000000-0000-0000-0000-000000000301",
+		"1",
+		"\\xdeadbeef",
+		"5",
+		"1",
+		"\\N",
+		"\\N",
+		"excluded",
+		"2024-01-02 03:04:05",
+		"2024-01-02 03:04:05",
+		"\\N",
+	}, "\t")
+
+	contents := strings.Join([]string{
+		"INSERT INTO users (uuid, first_name, last_name, username, email, password_hash, public_token) VALUES ('00000000-0000-0000-0000-000000000101', 'Alice', 'Smith', 'asmith', 'alice@example.com', 'hash', 'token');",
+		"INSERT INTO public.api_keys (id, uuid, account_name, public_key, secret_key, created_at, updated_at, deleted_at) VALUES (1, '00000000-0000-0000-0000-000000000201', 'demo-account', '\\x01', '\\x02', NOW(), NOW(), NULL);",
+		"SELECT pg_catalog.setval('public.api_keys_id_seq', 99, true);",
+		"COPY public.api_key_signatures (id, uuid, api_key_id, signature, max_tries, current_tries, expires_at, expired_at, origin, created_at, updated_at, deleted_at) FROM stdin;",
+		copyRow,
+		"\\.",
+		"",
+	}, "\n")
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), contents)
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("seed from file: %v", err)
+	}
+
+	assertCount := func(table string, expected int64) {
+		t.Helper()
+		var count int64
+		if err := conn.Sql().Table(table).Count(&count).Error; err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if count != expected {
+			t.Fatalf("expected %d rows in %s, got %d", expected, table, count)
+		}
+	}
+
+	assertCount("users", 1)
+	assertCount("api_keys", 0)
+	assertCount("api_key_signatures", 0)
+}
+
+func TestSeedFromFileSkipsDropSequenceForExcludedTables(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	contents := strings.Join([]string{
+		"INSERT INTO users (uuid, first_name, last_name, username, email, password_hash, public_token) VALUES ('00000000-0000-0000-0000-000000000111', 'Jane', 'Doe', 'janedoe', 'jane@example.com', 'hash', 'token');",
+		"DROP SEQUENCE public.api_keys_id_seq;",
+		"",
+	}, "\n")
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), contents)
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("seed from file: %v", err)
+	}
+
+	var nextVal int64
+	if err := conn.Sql().Raw("SELECT nextval('public.api_keys_id_seq')").Scan(&nextVal).Error; err != nil {
+		t.Fatalf("nextval sequence: %v", err)
+	}
+
+	var userCount int64
+	if err := conn.Sql().Table("users").Count(&userCount).Error; err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+
+	if userCount != 1 {
+		t.Fatalf("expected 1 user after seeding, got %d", userCount)
+	}
+}
+
+func TestSeedFromFileSkipsDuplicateCreates(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	contents := strings.Join([]string{
+		"CREATE TABLE widgets (id SERIAL PRIMARY KEY, name TEXT NOT NULL);",
+		"INSERT INTO widgets (name) VALUES ('alpha'), ('beta');",
+	}, "\n")
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), contents)
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("first seed: %v", err)
+	}
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("second seed: %v", err)
+	}
+
+	var count int64
+	if err := conn.Sql().Table("widgets").Count(&count).Error; err != nil {
+		t.Fatalf("count widgets: %v", err)
+	}
+
+	if count != 4 {
+		t.Fatalf("expected 4 widgets after reseeding, got %d", count)
+	}
+}
+
+func TestSeedFromFileSkipsMissingOwnerRole(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	contents := strings.Join([]string{
+		"CREATE TABLE owner_change (id SERIAL PRIMARY KEY, note TEXT NOT NULL);",
+		"ALTER TABLE owner_change OWNER TO missing_role;",
+		"INSERT INTO owner_change (note) VALUES ('ok');",
+	}, "\n")
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), contents)
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("seed from file: %v", err)
+	}
+
+	type ownerRow struct {
+		Note string
+	}
+
+	var rows []ownerRow
+	if err := conn.Sql().Table("owner_change").Find(&rows).Error; err != nil {
+		t.Fatalf("query owner_change: %v", err)
+	}
+
+	if len(rows) != 1 || rows[0].Note != "ok" {
+		t.Fatalf("unexpected owner_change rows: %+v", rows)
+	}
+}
+
+func TestSeedFromFileSkipsMissingRelationAlter(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	contents := strings.Join([]string{
+		"ALTER TABLE missing_relation DROP CONSTRAINT missing_relation_pkey;",
+		"CREATE TABLE relation_keep (id SERIAL PRIMARY KEY, note TEXT NOT NULL);",
+		"INSERT INTO relation_keep (note) VALUES ('ok');",
+	}, "\n")
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), contents)
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("seed from file: %v", err)
+	}
+
+	type relationRow struct {
+		Note string
+	}
+
+	var rows []relationRow
+	if err := conn.Sql().Table("relation_keep").Find(&rows).Error; err != nil {
+		t.Fatalf("query relation_keep: %v", err)
+	}
+
+	if len(rows) != 1 || rows[0].Note != "ok" {
+		t.Fatalf("unexpected relation_keep rows: %+v", rows)
+	}
+}
+
+func TestSeedFromFileRunsMigrations(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	contents := strings.Join([]string{
+		"INSERT INTO categories (uuid, name, slug)",
+		"VALUES ('00000000-0000-0000-0000-00000000c001', 'Tech', 'tech');",
+	}, "\n")
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), contents)
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("seed from file: %v", err)
+	}
+
+	var count int64
+	if err := conn.Sql().Table("categories").Count(&count).Error; err != nil {
+		t.Fatalf("count categories: %v", err)
+	}
+
+	if count != 1 {
+		t.Fatalf("expected 1 category, got %d", count)
+	}
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("second seed from file: %v", err)
+	}
+
+	count = 0
+	if err := conn.Sql().Table("categories").Count(&count).Error; err != nil {
+		t.Fatalf("count categories after reseed: %v", err)
+	}
+
+	if count != 1 {
+		t.Fatalf("expected 1 category after reseed, got %d", count)
+	}
+}
+
+func TestSeedFromFileAllowsTrailingComment(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	contents := strings.Join([]string{
+		"CREATE TABLE comment_samples (id SERIAL PRIMARY KEY);",
+		"INSERT INTO comment_samples DEFAULT VALUES;",
+		"-- trailing comment without terminating semicolon",
+	}, "\n")
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), contents)
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("seed from file: %v", err)
+	}
+
+	var count int64
+	if err := conn.Sql().Table("comment_samples").Count(&count).Error; err != nil {
+		t.Fatalf("count comment_samples: %v", err)
+	}
+
+	if count != 1 {
+		t.Fatalf("expected 1 row, got %d", count)
+	}
+}
+
+func TestSeedFromFileSkipsMetaCommands(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	contents := strings.Join([]string{
+		"CREATE TABLE meta_samples (id SERIAL PRIMARY KEY, name TEXT NOT NULL);",
+		"\\unrestrict RxSYF91vrSQYWEkG1ncg4fXRoYz64lllqFyU6He6bfAOnQdm2YZx8nLWBqOC8XK",
+		"INSERT INTO meta_samples (name) VALUES ('alpha');",
+		"\\connect - oullin",
+		"INSERT INTO meta_samples (name) VALUES ('beta');",
+	}, "\n")
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), contents)
+
+	if err := importer.SeedFromFile(conn, environment, fileName); err != nil {
+		t.Fatalf("seed from file: %v", err)
+	}
+
+	var count int64
+	if err := conn.Sql().Table("meta_samples").Count(&count).Error; err != nil {
+		t.Fatalf("count meta_samples: %v", err)
+	}
+
+	if count != 2 {
+		t.Fatalf("expected 2 rows, got %d", count)
+	}
+}
+
+func TestSeedFromFileReportsUnterminatedStatementDetails(t *testing.T) {
+	conn, environment, cleanup := setupPostgresConnection(t)
+	t.Cleanup(cleanup)
+
+	contents := strings.Join([]string{
+		"CREATE TABLE debug_statements (id SERIAL PRIMARY KEY)",
+		"-- missing semicolon should trigger parser diagnostics",
+	}, "\n")
+
+	fileName := writeStorageFile(t, withSuffix(t, ".sql"), contents)
+
+	err := importer.SeedFromFile(conn, environment, fileName)
+	if err == nil {
+		t.Fatalf("expected parse error for unterminated statement")
+	}
+
+	if !strings.Contains(err.Error(), "unterminated statement") {
+		t.Fatalf("expected unterminated statement error, got %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "line 1") {
+		t.Fatalf("expected error to report line number, got %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "debug_statements") {
+		t.Fatalf("expected error to include statement preview, got %v", err)
+	}
+}
+
+func testEnvironment() *env.Environment {
+	return &env.Environment{App: env.AppEnvironment{Type: "local"}}
+}
+
+func writeStorageFile(t *testing.T, name, contents string) string {
+	t.Helper()
+
+	return writeStorageBytes(t, name, []byte(contents))
+}
+
+func writeStorageBytes(t *testing.T, name string, contents []byte) string {
+	t.Helper()
+
+	dir := filepath.Join("storage", "sql")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create storage dir: %v", err)
+	}
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatalf("write storage file: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("remove storage file: %v", err)
+		}
+	})
+
+	return name
+}
+
+func withSuffix(t *testing.T, suffix string) string {
+	t.Helper()
+
+	base := strings.ReplaceAll(strings.ToLower(t.Name()), "/", "_")
+	base = strings.ReplaceAll(base, " ", "_")
+	base = strings.ReplaceAll(base, ":", "_")
+
+	return fmt.Sprintf("%s_%d%s", base, time.Now().UnixNano(), suffix)
+}
+
+func setupPostgresConnection(t *testing.T) (*database.Connection, *env.Environment, func()) {
+	t.Helper()
+
+	if os.Getenv("IMPORTER_SKIP_INTEGRATION") == "1" || os.Getenv("SQLSEED_SKIP_INTEGRATION") == "1" {
+		t.Skip("importer integration tests disabled via IMPORTER_SKIP_INTEGRATION or SQLSEED_SKIP_INTEGRATION")
+	}
+
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not installed")
+	}
+
+	if err := exec.Command("docker", "ps").Run(); err != nil {
+		t.Skip("docker not running")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	pg, err := postgres.RunContainer(ctx,
+		testcontainers.WithImage("postgres:16-alpine"),
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("secret"),
+		postgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		t.Fatalf("container run err: %v", err)
+	}
+
+	host, err := pg.Host(ctx)
+	if err != nil {
+		t.Fatalf("host err: %v", err)
+	}
+
+	port, err := pg.MappedPort(ctx, "5432/tcp")
+	if err != nil {
+		t.Fatalf("port err: %v", err)
+	}
+
+	e := &env.Environment{
+		App: env.AppEnvironment{Type: "local"},
+		DB: env.DBEnvironment{
+			UserName:     "test",
+			UserPassword: "secret",
+			DatabaseName: "testdb",
+			Port:         port.Int(),
+			Host:         host,
+			DriverName:   database.DriverName,
+			SSLMode:      "disable",
+			TimeZone:     "UTC",
+		},
+	}
+
+	conn, err := database.MakeConnection(e)
+	if err != nil {
+		t.Fatalf("make connection: %v", err)
+	}
+
+	cleanup := func() {
+		if err := conn.Ping(); err == nil {
+			conn.Close()
+		}
+
+		if err := pg.Terminate(context.Background()); err != nil {
+			t.Logf("failed to terminate container: %v", err)
+		}
+	}
+
+	return conn, e, cleanup
+}

--- a/metal/makefile/db.mk
+++ b/metal/makefile/db.mk
@@ -1,5 +1,5 @@
 .PHONY: db\:sh db\:up db\:down db\:logs db\:bash db\:fresh
-.PHONY: db\:secure db\:seed db\:migrate db\:migrate\:create db\:migrate\:force db\:rollback db\:chmod
+.PHONY: db\:secure db\:seed db\:import db\:migrate db\:migrate\:create db\:migrate\:force db\:rollback db\:chmod
 
 # --- Docker Services
 DB_API_RUNNER_SERVICE := api-runner
@@ -57,7 +57,15 @@ db\:secure:
 
 db\:seed:
 	docker compose --env-file ./.env run --rm $(DB_MIGRATE_DOCKER_ENV_FLAGS) $(DB_API_RUNNER_SERVICE) \
- 		 go run ./database/seeder/main.go
+		go run ./database/seeder/main.go
+
+db\:import:
+	@if [ -z "$(file)" ]; then \
+	echo "usage: make db:import file=path/to/seed.sql"; \
+	exit 1; \
+	fi
+	docker compose --env-file ./.env run --rm $(DB_MIGRATE_DOCKER_ENV_FLAGS) $(DB_API_RUNNER_SERVICE) \
+		go run ./database/seeder/importer/cmd/importer --file $(file)
 
 # -------------------------------------------------------------------------------------------------------------------- #
 # --- Migrations


### PR DESCRIPTION
## Summary
- move the SQL import runner into the new `database/seeder/importer` package and rename its error prefixes accordingly
- point the CLI entrypoint and `db:import` make target at the importer package
- keep integration tests skippable via either the new importer flag or the previous sqlseed flag

## Testing
- IMPORTER_SKIP_INTEGRATION=1 go test ./...
- go test -coverpkg=./... ./database/... -coverprofile=coverage-database-1.25.1.out *(fails: go toolchain lacks `covdata`)*

------
https://chatgpt.com/codex/tasks/task_e_68e359dad520833388f1afd5170f94dc