### PR TITLE
chore: Replace contact email with hi@ollin.sh

### DIFF
--- a/metal/cli/seo/generator_test.go
+++ b/metal/cli/seo/generator_test.go
@@ -258,7 +258,7 @@ func TestGeneratorGenerateAllPages(t *testing.T) {
 		t.Fatalf("expected contact heading in contact page: %q", contactContent)
 	}
 
-	if !strings.Contains(contactContent, "mailto:gus@oullin.io") {
+	if !strings.Contains(contactContent, "mailto:hi@ollin.sh") {
 		t.Fatalf("expected contact page to include email link: %q", contactContent)
 	}
 

--- a/storage/fixture/profile.json
+++ b/storage/fixture/profile.json
@@ -4,7 +4,7 @@
         "nickname": "gus",
         "handle": "gocanto",
         "name": "Gustavo Ocanto",
-        "email": "gus@oullin.io",
+        "email": "hi@ollin.sh",
         "profession": "Founder of Oullin",
         "skills": [
             {


### PR DESCRIPTION
## Summary
- Replace `gus@oullin.io` with `hi@ollin.sh` in the profile fixture so the generated contact page surfaces the new address
- Update the matching SEO generator test assertion to expect the new `mailto:` value

## Test plan
- [x] `go test ./metal/cli/seo/...`
- [x] `grep -rn "gus@oullin" .` returns no results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal configuration and test data fixtures.

---

*Note: This release contains primarily internal updates with minimal end-user impact.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->