### PR TITLE
Use scoped token for VPS image pulls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,7 @@ jobs:
     name: Deploy to VPS
     needs: build-and-push
     runs-on: ubuntu-24.04
+    # GHCR pulls require package access; all other token permissions stay disabled.
     permissions:
       packages: read
 
@@ -72,12 +73,13 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USERNAME }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -Eeuo pipefail
             IMAGE_TAG=${{ needs.build-and-push.outputs.IMAGE_TAG }}
 
             echo "🔑 Logging into GitHub Container Registry ..."
-            echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 
             echo "🚚 Pulling latest images with tag: $IMAGE_TAG"
             docker pull ghcr.io/oullin/oullin_api:$IMAGE_TAG
@@ -107,3 +109,6 @@ jobs:
             ./deployment
 
             echo "✅ Deployment completed!"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,8 @@ jobs:
     name: Deploy to VPS
     needs: build-and-push
     runs-on: ubuntu-24.04
+    permissions:
+      packages: read
 
     steps:
       - name: SSH and Pull Images on VPS
@@ -75,7 +77,7 @@ jobs:
             IMAGE_TAG=${{ needs.build-and-push.outputs.IMAGE_TAG }}
 
             echo "🔑 Logging into GitHub Container Registry ..."
-            echo ${{ secrets.DOCKER_REGISTRY_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
             echo "🚚 Pulling latest images with tag: $IMAGE_TAG"
             docker pull ghcr.io/oullin/oullin_api:$IMAGE_TAG


### PR DESCRIPTION
## Summary

- grant the VPS deploy job read-only access to linked GHCR packages
- authenticate the remote Docker pull with the run-scoped GitHub token
- remove the deploy path's dependency on the rejected long-lived registry secret

## Evidence

The two latest production runs built and published both images, then failed before changing the VPS with `Get "https://ghcr.io/v2/": denied: denied`. The publishing job already proves this repository is linked to the packages.

The next push to `main` will exercise the complete production deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment authentication for pulling container images.
  * Added the required read-only package permission to the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->